### PR TITLE
Mapbox GL JS > 1.6.0 compatibility

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,7 +3,7 @@
     display: none;
 }
 
-.mapboxgl-style-list button
+.mapboxgl-ctrl-group .mapboxgl-style-list button
 {
     background: none;
     border: none;
@@ -13,6 +13,7 @@
     padding: 8px 8px 6px;
     text-align: right;
     width: 100%;
+    height: auto;
 }
 
 .mapboxgl-style-list button.active


### PR DESCRIPTION
It seems recent Mapbox versions are setting a style on the mapboxgl-ctrl-group that cannot be overridden here (without forcing !important). Being more specific from a CSS standpoint on the style seems to fix the issue, we also need to force the height back to auto.