### PR TITLE
Prevent selecting already active style

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -24,6 +24,9 @@ class MapboxStyleSwitcherControl {
             styleElement.dataset.uri = JSON.stringify(style.uri);
             styleElement.addEventListener("click", event => {
                 const srcElement = event.srcElement;
+                if (srcElement.classList.contains("active")) {
+                    return;
+                }
                 this.map.setStyle(JSON.parse(srcElement.dataset.uri));
                 this.mapStyleContainer.style.display = "none";
                 this.styleButton.style.display = "block";

--- a/dist/index.js
+++ b/dist/index.js
@@ -16,9 +16,11 @@ class MapboxStyleSwitcherControl {
         this.controlContainer.classList.add("mapboxgl-ctrl-group");
         this.mapStyleContainer = document.createElement("div");
         this.styleButton = document.createElement("button");
+        this.styleButton.setAttribute('type', 'button');
         this.mapStyleContainer.classList.add("mapboxgl-style-list");
         for (const style of this.styles) {
             const styleElement = document.createElement("button");
+            styleElement.setAttribute('type', 'button');
             styleElement.innerText = style.title;
             styleElement.classList.add(style.title.replace(/[^a-z0-9-]/gi, '_'));
             styleElement.dataset.uri = JSON.stringify(style.uri);


### PR DESCRIPTION
Prevent selecting already active style to prevent removing added layers to the map.

**The problem**:
If you have added layers on the map, they will be removed after switching a style. I'm just re-adding them to the style:
`map.on('style.load', () => { // add layers here });`

This code is not used if you try to switch to already active style:

![map_switcher_problem](https://user-images.githubusercontent.com/6932424/84519816-4265bb00-acdb-11ea-8e00-83305e56b9d2.gif)

**The fix**:
We need just prevent selecting already active style:

![map_switcher_fix](https://user-images.githubusercontent.com/6932424/84519884-5e695c80-acdb-11ea-953f-efd62dc4d866.gif)
