### PR TITLE
docs(readme): update versions for light and dark styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ import { MapboxStyleDefinition, MapboxStyleSwitcherControl } from "mapbox-gl-sty
 const styles: MapboxStyleDefinition[] = [
     {
         title: "Dark",
-        uri:"mapbox://styles/mapbox/dark-v9"
+        uri:"mapbox://styles/mapbox/dark-v11"
     },
     {
         title: "Light",
-        uri:"mapbox://styles/mapbox/light-v9"
+        uri:"mapbox://styles/mapbox/light-v11"
     }
 ];
 


### PR DESCRIPTION
Following the list from https://docs.mapbox.com/mapbox-gl-js/guides/styles/#classic-style-templates-and-custom-styles v9 should now be v11 for light and dark